### PR TITLE
Fix deprecation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Then use the Sprig function and tags as normal in your control panel templates.
 
 ```twig
 {{ sprig('_components/search') }}
-
-{{ sprig.script }}
 ```
 
 Sprig plugin issues should be reported to https://github.com/putyourlightson/craft-sprig/issues


### PR DESCRIPTION
`sprig.script` has been deprecated. It is no longer required and can be safely removed.

PS. I can tell you're not working on this with `plugindev` ;) 