### PR TITLE
Make logging cleaner, more compatible

### DIFF
--- a/src/Sprig.php
+++ b/src/Sprig.php
@@ -157,7 +157,7 @@ class Sprig extends Module
         if (Craft::getLogger()->dispatcher) {
             Craft::getLogger()->dispatcher->targets[] = new MonologTarget([
                 'name' => 'sprig',
-                'categories' => ['sprig'],
+                'categories' => ['putyourlightson\sprig\*'],
                 'level' => LogLevel::INFO,
                 'logContext' => false,
                 'allowLineBreaks' => false,

--- a/src/services/ComponentsService.php
+++ b/src/services/ComponentsService.php
@@ -24,7 +24,6 @@ use putyourlightson\sprig\Sprig;
 use Twig\Markup;
 use yii\base\InvalidArgumentException;
 use yii\base\Model;
-use yii\log\Logger;
 use yii\web\BadRequestHttpException;
 use yii\web\Request;
 
@@ -335,7 +334,7 @@ class ComponentsService extends BaseComponent
         }
 
         if (preg_last_error() == PREG_BACKTRACK_LIMIT_ERROR) {
-            Craft::getLogger()->log('Backtrack limit was exhausted!', Logger::LEVEL_ERROR, 'sprig');
+            Craft::error('Backtrack limit was exhausted!', __METHOD__);
         }
 
         return $matches[0] ?? [];
@@ -353,7 +352,7 @@ class ComponentsService extends BaseComponent
 
             $attributes = Html::parseTagAttributes($tag);
         } catch (InvalidArgumentException $exception) {
-            Craft::getLogger()->log($exception->getMessage(), Logger::LEVEL_ERROR, 'sprig');
+            Craft::error($exception->getMessage(), __METHOD__);
 
             return null;
         }


### PR DESCRIPTION
This PR cleans up the logging to a file, and has it using the normal, [Craft compatible](https://craftcms.com/docs/4.x/logging.html#using-craft-s-logger) error logging via:

* `Craft::trace()`
* `Craft::debug()`
* `Craft::info()`
* `Craft::warning()`
* `Craft::error()`

...rather than the cumbersome:

```php
use yii\log\Logger;

Craft::getLogger()->log('Backtrack limit was exhausted!', Logger::LEVEL_ERROR, 'sprig');
```

You just do:

```php
Craft::error('Backtrack limit was exhausted!', __METHOD__);
```

...and it all "just works" in exactly the same log format, to exactly the same file as before. It's just a single line change where the logger is allocated:

```php
                'categories' => ['putyourlightson\sprig\*'],
```