### PR TITLE
Fix bug in `ComponentsService` checking if `View` constant is defined

### DIFF
--- a/src/services/ComponentsService.php
+++ b/src/services/ComponentsService.php
@@ -162,7 +162,7 @@ class ComponentsService extends BaseComponent
          * View::EVENT_AFTER_REGISTER_ASSET_BUNDLE was added in Craft 4.5.0.
          * TODO: Remove the outer condition in Sprig Core 3.
          */
-        if (defined(View::EVENT_AFTER_REGISTER_ASSET_BUNDLE)) {
+        if (defined('View::EVENT_AFTER_REGISTER_ASSET_BUNDLE')) {
             Event::on(View::class, View::EVENT_AFTER_REGISTER_ASSET_BUNDLE,
                 function(AssetBundleEvent $event) use ($attributes) {
                     if ($event->bundle instanceof HtmxAssetBundle) {


### PR DESCRIPTION
Addresses the bug described here: https://github.com/putyourlightson/craft-sprig/issues/344

Turns out checking for existence of a constant needs to be done by the constant name as a string.