### PR TITLE
Update ComponentsService.php

### DIFF
--- a/src/services/ComponentsService.php
+++ b/src/services/ComponentsService.php
@@ -309,6 +309,10 @@ class ComponentsService extends BaseComponent
             return new SprigPlayground(['variables' => $variables]);
         }
 
+        if (class_exists($component)) {
+            return new $component(['variables' => $variables]);
+        }
+
         $componentClass = self::COMPONENT_NAMESPACE . $component;
 
         if (!class_exists($componentClass)) {


### PR DESCRIPTION
Added the ability to pass a full namespace into the sprig tag.

This use case would be in the case of having a class component in a custom plugin/module and wanting to keep the code in the same namespace.

As an example:

{{ sprig("\\modules\\sprig\\ClassComponent" }}