### PR TITLE
Fix missing Craft import

### DIFF
--- a/src/variables/SprigVariable.php
+++ b/src/variables/SprigVariable.php
@@ -12,6 +12,7 @@ use putyourlightson\sprig\services\ComponentsService;
 use putyourlightson\sprig\Sprig;
 use yii\db\Query;
 use yii\web\AssetBundle;
+use Craft;
 
 class SprigVariable
 {


### PR DESCRIPTION
Updating to the latest 2.x sprig caused this error:

Error
Class "putyourlightson\sprig\variables\Craft" not found


\Craft isn't imported into the namespace, this should fix it.